### PR TITLE
Update .github/settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -5,3 +5,4 @@ repository:
   description: Github Action for https://github.com/dvmtn/datadog-notify, which sends an event api call to Datadog
   homepage: https://cloudposse.com/accelerate
   topics: ""
+


### PR DESCRIPTION
## what
- Update `.github/settings.yml` 
- Drop `.github/auto-release.yml` files

## why
- Re-apply `.github/settings.yml` from org level
- Use organization level auto-release settings

## references
- DEV-1242 Add protected tags with Repository Rulesets on GitHub
